### PR TITLE
Expose more Verify related APIs

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -26,6 +26,13 @@ type VerifyErr struct {
 	reason VerifyReasons
 }
 
+func NewVerifyErr(msg string, reason VerifyReasons) *VerifyErr {
+	return &VerifyErr{
+		msg:    msg,
+		reason: reason,
+	}
+}
+
 type AuthzErrWithReason interface {
 	XJWTVerifyReason() VerifyReasons
 }
@@ -72,7 +79,7 @@ func isAllowedAlgo(in jose.SignatureAlgorithm) bool {
 	return false
 }
 
-// Verify verifies a JWT.
+// Verify verifies a JWT, and returns a map containing the payload claims
 //
 // It is paranoid.  It has default settings for "real world" JWT usage as an HTTP Header.
 //
@@ -80,6 +87,31 @@ func isAllowedAlgo(in jose.SignatureAlgorithm) bool {
 //
 // But its safe.
 func Verify(input []byte, vc VerifyConfig) (map[string]interface{}, error) {
+	payload, err := VerifyRaw(input, vc)
+	if err != nil {
+		return nil, err
+	}
+
+	data := make(map[string]interface{})
+	err = json.Unmarshal(payload, &data)
+	if err != nil {
+		return nil, &VerifyErr{
+			msg:    fmt.Sprintf("xjwt: data did not contain JSON: %v", err.Error()),
+			reason: JWT_MALFORMED,
+		}
+	}
+	return data, nil
+}
+
+// Verify verifies a JWT, and returns the raw payload as a byte string
+//
+// It is paranoid.  It has default settings for "real world" JWT usage as an HTTP Header.
+//
+// It will reject potentially valid JWTs nd related specifications.
+//
+// But its safe.
+func VerifyRaw(input []byte, vc VerifyConfig) ([]byte, error) {
+
 	var now time.Time
 	if vc.Now == nil {
 		now = time.Now()
@@ -227,17 +259,7 @@ func Verify(input []byte, vc VerifyConfig) (map[string]interface{}, error) {
 		}
 	}
 
-	data := make(map[string]interface{})
-
-	err = json.Unmarshal(payload, &data)
-	if err != nil {
-		return nil, &VerifyErr{
-			msg:    fmt.Sprintf("xjwt: data did not contain JSON: %v", err.Error()),
-			reason: JWT_MALFORMED,
-		}
-	}
-
-	return data, nil
+	return payload, nil
 }
 
 // from https://github.com/coreos/go-oidc/blob/master/oidc.go


### PR DESCRIPTION
- Add NewVerifyErr() so external modules can construct errors.
- Add VerifyRaw() to get the raw bytes w/o parsing JSON.
- Expose control of Max Expiration option
