### PR TITLE
"v2" of xjwt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: go
+
+go:
+  - "1.9"
+  - "1.10"
+  - "master"

--- a/NOTICE
+++ b/NOTICE
@@ -4,7 +4,7 @@ Copyright 2017 ScaleFT, Inc.
 This product includes software developed at ScaleFT, Inc.
 (https://www.scaleft.com/).
 
-verify.go is based on <https://github.com/coreos/go-oidc/blob/master/verify.go>:
+verify.go was originally code from <https://github.com/coreos/go-oidc>:
 
         This product includes software developed at CoreOS, Inc.
         (http://www.coreos.com/).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # xjwt: small extensions for implementing JWT-based systems
 
+[![GoDoc](https://godoc.org/github.com/ScaleFT/xjwt?status.svg)](https://godoc.org/github.com/ScaleFT/xjwt)
+[![Build Status](https://travis-ci.org/ScaleFT/xjwt.svg?branch=master)](https://travis-ci.org/ScaleFT/xjwt)
+
+# Methods
+
+## JWT Verification
+
+ `xjwt.Verify` and  `xjwt.VerifyRaw` are strict verifying methods for validating a JWT is valid and well formed.
+
+## Remote JWK Keysets
+
+`xkeyset.RemoteKeyset` wraps a remote JWKs URL, caching and refreshing a list of JWKs in the background.
+
+## jose.v2 shortcuts
+
+### RandomNonce
+
+`xjwt.RandomNonce` provides a basic, random value, conforming to the `jose.NonceSource` interface.
+
+### Converting PEM encoding to JOSE types
+
+`xjwt.ParsePrivateKey` converts a private key from a PEM encoding to a `*jose.JSONWebKey`.
+
+# License
+
+`xjwt` is licensed under the Apache License Version 2.0. See the [LICENSE file](./LICENSE) for details.

--- a/key.go
+++ b/key.go
@@ -11,6 +11,9 @@ import (
 )
 
 // ParsePrivateKey converts a private key from a PEM encoding to a *jose.JSONWebKey.
+//
+// Optionally, a passphrase for an encrypted X.509 document can be passed in.  If the
+// contents of the PEM is not encrypted, passphrase is ignored.
 func ParsePrivateKey(privateKey []byte, passphrase []byte) (*jose.JSONWebKey, jose.SignatureAlgorithm, error) {
 	pk, err := unmarshalPrivateKey(privateKey, passphrase)
 	if err != nil {

--- a/pem.go
+++ b/pem.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 )
 
+// ErrIncorrectPassword means when attempting to parse an encrypted PEM file, the password was likely incorrect
 var ErrIncorrectPassword = x509.IncorrectPasswordError
 
 func unmarshalPrivateKey(data []byte, passphrase []byte) (crypto.PrivateKey, error) {

--- a/rand.go
+++ b/rand.go
@@ -14,6 +14,7 @@ type RandomNonce struct {
 
 var _ jose.NonceSource = (*RandomNonce)(nil)
 
+// Nonce returns a random string or an error
 func (rn *RandomNonce) Nonce() (string, error) {
 	s := rn.Size
 	if s == 0 {

--- a/verify.go
+++ b/verify.go
@@ -9,23 +9,34 @@ import (
 	jose "gopkg.in/square/go-jose.v2"
 )
 
+// VerifyReasons expresses why a JWT was not valid.
 type VerifyReasons int32
 
 const (
-	JWT_UNKNOWN           VerifyReasons = 0
-	JWT_NOT_PRESENT       VerifyReasons = 1
-	JWT_EXPIRED           VerifyReasons = 2
+	// JWT_UNKNOWN means the JWT could not be verified for unknown reasons.
+	JWT_UNKNOWN VerifyReasons = 0
+	// JWT_NOT_PRESENT means the JWT was empty or otherwise not present.
+	JWT_NOT_PRESENT VerifyReasons = 1
+	// JWT_EXPIRED means the JWT has expired, and a refresh might be needed.
+	JWT_EXPIRED VerifyReasons = 2
+	// JWT_INVALID_SIGNATURE means the JWT's signature is invalid.
 	JWT_INVALID_SIGNATURE VerifyReasons = 3
-	JWT_NO_VALIDATORS     VerifyReasons = 4
-	JWT_MALFORMED         VerifyReasons = 5
-	JWT_EXPECT_MISMATCH   VerifyReasons = 6
+	// JWT_NO_VALIDATORS means no matching JWK could be found to validate the JWT.
+	// This could be caused by JWKs expiring or not being rotated correctly.
+	JWT_NO_VALIDATORS VerifyReasons = 4
+	// JWT_MALFORMED means the JWT contained unexpected fields or data.
+	JWT_MALFORMED VerifyReasons = 5
+	// JWT_EXPECT_MISMATCH means the JWT did not contain the expected claims, such as Audience or Subject.
+	JWT_EXPECT_MISMATCH VerifyReasons = 6
 )
 
+// VerifyErr repersents an error from Verify meets the error and AuthzErrWithReason interfaces.
 type VerifyErr struct {
 	msg    string
 	reason VerifyReasons
 }
 
+// NewVerifyErr creates a new VerifyErr
 func NewVerifyErr(msg string, reason VerifyReasons) *VerifyErr {
 	return &VerifyErr{
 		msg:    msg,
@@ -33,14 +44,17 @@ func NewVerifyErr(msg string, reason VerifyReasons) *VerifyErr {
 	}
 }
 
+// AuthzErrWithReason is used to extract additional reasons a verification failed from an error interface.
 type AuthzErrWithReason interface {
 	XJWTVerifyReason() VerifyReasons
 }
 
+// Error returns a human readable description of an error
 func (e *VerifyErr) Error() string {
 	return e.msg
 }
 
+// XJWTVerifyReason returns the reason verification failed
 func (e *VerifyErr) XJWTVerifyReason() VerifyReasons {
 	return e.reason
 }
@@ -48,14 +62,23 @@ func (e *VerifyErr) XJWTVerifyReason() VerifyReasons {
 // TODO(pquerna): lower this after more research in realistic expiration times
 const defaultMaxExpirationFromNow = (time.Hour * 24) * 91
 
+// VerifyConfig expreses the possible options for validating a JWT
 type VerifyConfig struct {
-	ExpectedIssuer       string
-	ExpectedSubject      string
-	ExpectedAudience     string
-	ExpectedNonce        string
-	Now                  func() time.Time
+	// ExpectedIssuer validates the iss claim of a JWT matches this value
+	ExpectedIssuer string
+	// ExpectedSubject validates the sub claim of a JWT matches this value
+	ExpectedSubject string
+	// ExpectedAudience validates that the aud claim of a JWT contains this value
+	ExpectedAudience string
+	// ExpectedNonce validates that the nonce claim of a JWT matches this value
+	ExpectedNonce string
+	// Now is a callback to the current time, if not provided time.Now is used
+	Now func() time.Time
+	// MaxExpirationFromNow is how far into the future to allow a JWT to be valid for.
+	// This can be used to mitigate against some types of  "golden ticket attacks".
 	MaxExpirationFromNow time.Duration
-	KeySet               *jose.JSONWebKeySet
+	// KeySet is a set of JWKs that are trusted by the verifier, and used to validate the JWT.
+	KeySet *jose.JSONWebKeySet
 }
 
 var validSignatureAlgorithm = []jose.SignatureAlgorithm{
@@ -83,10 +106,12 @@ func isAllowedAlgo(in jose.SignatureAlgorithm) bool {
 // Verify verifies a JWT, and returns a map containing the payload claims
 //
 // It is paranoid.  It has default settings for "real world" JWT usage as an HTTP Header.
-//
 // It will reject potentially valid JWTs nd related specifications.
 //
-// But its safe.
+// If an error is encountered, the error returned may implement the xjwt.AuthzErrWithReason
+// interface.  This interface can be used to find the reason a JWT did not validate, enumerated by
+// the VerifyReasons type. This is because some errors (like an expired JWT), might be a good reason
+// to refresh from a JWT source, but others like a parse error might be best handled as a hard error.
 func Verify(input []byte, vc VerifyConfig) (map[string]interface{}, error) {
 	payload, err := VerifyRaw(input, vc)
 	if err != nil {
@@ -104,15 +129,9 @@ func Verify(input []byte, vc VerifyConfig) (map[string]interface{}, error) {
 	return data, nil
 }
 
-// Verify verifies a JWT, and returns the raw payload as a byte string
-//
-// It is paranoid.  It has default settings for "real world" JWT usage as an HTTP Header.
-//
-// It will reject potentially valid JWTs nd related specifications.
-//
-// But its safe.
+// VerifyRaw verifies a JWT with the same constaints as xjwt.Verify,
+// but returns the payload as a byte slice
 func VerifyRaw(input []byte, vc VerifyConfig) ([]byte, error) {
-
 	var now time.Time
 	if vc.Now == nil {
 		now = time.Now()
@@ -268,8 +287,8 @@ func VerifyRaw(input []byte, vc VerifyConfig) ([]byte, error) {
 	return payload, nil
 }
 
-// from https://github.com/coreos/go-oidc/blob/master/oidc.go
-
+// idToken is a set of common claims in a JWT.
+// This struct was originally from https://github.com/coreos/go-oidc/blob/master/oidc.go
 type idToken struct {
 	Issuer    string   `json:"iss"`
 	Subject   string   `json:"sub"`

--- a/xkeyset/keyset.go
+++ b/xkeyset/keyset.go
@@ -22,7 +22,7 @@ const (
 	xjwtOpenTracingTag = "com.scaleft.xjwt"
 )
 
-type KeysetOptions struct {
+type Options struct {
 	UserAgent        string
 	URL              string
 	Client           *http.Client
@@ -31,15 +31,15 @@ type KeysetOptions struct {
 	RefreshWarning   func(err error)
 }
 
-// NewRemoteKeyset creates a JSON Keyset that is cached in memory.
+// New creates a JSON Keyset that is cached in memory.
 //
 // On creation, it will do a block HTTP request to load the initial keyset.
 //
 // After initial load, it will refresh the cached keyset, any consumers may see
 // older versions of the cache until the refresh is complete.
 //
-// NewRemoteKeyset emits opentracing spans on the supplied context when fetching the keyset.
-func NewRemoteKeyset(ctx context.Context, opts KeysetOptions) (*RemoteKeyset, error) {
+// New emits opentracing spans on the supplied context when fetching the keyset.
+func New(ctx context.Context, opts Options) (*RemoteKeyset, error) {
 	ctx, cfunc := context.WithCancel(ctx)
 	rk := &RemoteKeyset{
 		ctx:    ctx,
@@ -73,7 +73,7 @@ func NewRemoteKeyset(ctx context.Context, opts KeysetOptions) (*RemoteKeyset, er
 }
 
 type RemoteKeyset struct {
-	opts KeysetOptions
+	opts Options
 
 	ctx   context.Context
 	cfunc context.CancelFunc
@@ -128,7 +128,7 @@ func (rk *RemoteKeyset) fetchKeyset() (*jose.JSONWebKeySet, time.Duration, error
 	if rk.opts.UserAgent != "" {
 		req.Header.Set("User-Agent", rk.opts.UserAgent)
 	} else {
-		req.Header.Set("User-Agent", "xjwt.go/0.1.0")
+		req.Header.Set("User-Agent", "xjwt-keyset.go/0.1.0")
 	}
 
 	sp, ctx := opentracing.StartSpanFromContext(ctx, "xjwt.keyset.fetch")


### PR DESCRIPTION
- Moves Remote Keyset into its own sub-package of `xkeyset`.  This avoids pulling in the opentracing, cachecontrol, and other dependencies if you are just using the other methods.  This is a breaking API change.
- Adds more docs and expands the README.md